### PR TITLE
Round borders for highlight

### DIFF
--- a/styles/wta-vocab-game-styles.css
+++ b/styles/wta-vocab-game-styles.css
@@ -29,6 +29,7 @@ div {
 
 div.word:hover {
 	border: 2px solid blue !important;
+	border-radius: 1em;
 }
 
 footer {


### PR DESCRIPTION
Give the borders which highlight a moused-over word round corners to match the buttons.